### PR TITLE
Fix destroy sequence to prevent synchronization problem

### DIFF
--- a/xdp_user/src/main.cpp
+++ b/xdp_user/src/main.cpp
@@ -218,8 +218,8 @@ int main(int argc, char** argv) {
 	for(uint32_t i = 0; i < size; i++) {
 		pthread_join(threads[i], NULL);
 
-		delete drivers[i];
 		destroy(callbacks[i]);
+		delete drivers[i];
 	}
 
     dlclose(handle);


### PR DESCRIPTION
* If user packetlet creates thread joined at packetlet destructor, deleting driver first could incur 'use-after-free'
* In xdp_user main(), destroy callback first and delete driver