### PR TITLE
Add lock to xdp_user driver flush()

### DIFF
--- a/xdp_user/src/driver.h
+++ b/xdp_user/src/driver.h
@@ -56,6 +56,7 @@ protected:
 
 	uint64_t alloc_frame();
 	void free_frame(uint64_t frame);
+	void _free_frame(uint64_t frame);
 	
 public:
 	uint32_t		id;


### PR DESCRIPTION
* To avoid race condition in multithread send(), add spinlock to flush()