### PR TITLE
Fix and add dict support function to user config

### DIFF
--- a/include/pv/config.h
+++ b/include/pv/config.h
@@ -78,6 +78,14 @@ enum pv_config_type pv_config_get_type(const char* key);
 size_t pv_config_get_size(const char* key);
 
 /**
+ * Get the key name of given dict.
+ * @param dict key of dict object.
+ * @param key_index 0 based key index. @see pv_config_get_size
+ * @return key's name
+ */
+char* pv_config_get_key(const char* dict, int key_index);
+
+/**
  * Get string value of config
  * @param key key to look for
  * @return a string. null if not found. @see pv_config_has

--- a/pypv/config.py
+++ b/pypv/config.py
@@ -25,6 +25,7 @@ def convert(config: Union[int, float, str, bool, dict], root='') -> str:
         if len(config.keys()) != len(set(map(str, config.keys()))):
             raise ValueError('Same keyname as str is not allowed')
         for key in config.keys():
+            key = str(key)
             if not is_valid_keyname(key):
                 raise ValueError(f'Key name "{key}" is not allowed')
 

--- a/src/config.c
+++ b/src/config.c
@@ -210,11 +210,10 @@ bool pv_config_has(const char* key) {
 
 enum pv_config_type pv_config_get_type(const char* key) {
     size_t key_type_size = strlen(key) + strlen("/:type") + 1;
-    char* key_type = malloc(key_type_size);
+    char key_type[key_type_size];
     snprintf(key_type, key_type_size, "%s/:type", key);
 
     char* type = map_get(config_map, key_type);
-    free(key_type);
 
     if (type == NULL) {
         return PV_CONFIG_UNKNOWN;
@@ -237,17 +236,30 @@ enum pv_config_type pv_config_get_type(const char* key) {
 
 size_t pv_config_get_size(const char* key) {
     size_t key_length_size = strlen(key) + strlen("/:length") + 1;
-    char* key_length = malloc(key_length_size);
+    char key_length[key_length_size];
     snprintf(key_length, key_length_size, "%s/:length", key);
 
     char* length = map_get(config_map, key_length);
-    free(key_length);
 
     if (length == NULL) {
         return -1;
     }
 
     return atoi(length);
+}
+
+char* pv_config_get_key(const char* dict, int key_index) {
+    if (pv_config_get_type(dict) != PV_CONFIG_DICT) {
+        return NULL;
+    }
+
+    const size_t key_value_size = strlen(dict) + strlen("/:keys[xx]") + 1;
+    char key_value[key_value_size];
+
+    snprintf(key_value, key_value_size, "%s/:keys[%d]", dict, key_index);
+    char* value = map_get(config_map, key_value);
+
+    return value;
 }
 
 char* pv_config_get_str(const char* key) {
@@ -258,12 +270,11 @@ char* pv_config_get_str(const char* key) {
         return NULL;
     }
 
-    size_t key_value_size = strlen(key) + 1 + 1;
-    char* key_value = malloc(key_value_size);
+    const size_t key_value_size = strlen(key) + 1 + 1;
+    char key_value[key_value_size];
     snprintf(key_value, key_value_size, "%s/", key);
 
     char* value = map_get(config_map, key_value);
-    free(key_value);
     return value;
 }
 
@@ -275,12 +286,11 @@ int pv_config_get_num(const char* key) {
         return -1;
     }
 
-    size_t key_value_size = strlen(key) + 1 + 1;
-    char* key_value = malloc(key_value_size);
+    const size_t key_value_size = strlen(key) + 1 + 1;
+    char key_value[key_value_size];
     snprintf(key_value, key_value_size, "%s/", key);
 
     char* value = map_get(config_map, key_value);
-    free(key_value);
     if (value == NULL) {
         return -1;
     }
@@ -296,12 +306,11 @@ bool pv_config_get_bool(const char* key) {
         return false;
     }
 
-    size_t key_value_size = strlen(key) + 1 + 1;
-    char* key_value = malloc(key_value_size);
+    const size_t key_value_size = strlen(key) + 1 + 1;
+    char key_value[key_value_size];
     snprintf(key_value, key_value_size, "%s/", key);
 
     char* value = map_get(config_map, key_value);
-    free(key_value);
     if (value == NULL) {
         return false;
     }


### PR DESCRIPTION
1. Add support for non-str type dict key like this:
```yaml
some:
  3: tres
  42: The answer to life, the universe, and everything
```

2. Add support function to get key name from user config - `pv_config_get_key`