### PR TITLE
Add support for core related configs

### DIFF
--- a/examples/dump/src/main.c
+++ b/examples/dump/src/main.c
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <pv/config.h>
 #include <pv/net/ethernet.h>
 #include <pv/nic.h>
 #include <pv/packet.h>
@@ -12,6 +13,15 @@ int main(int argc, char** argv) {
     }
 
     struct pv_packet* packets[64];
+
+    printf("Getting cores\n");
+    int cores[16];
+    size_t cores_count = pv_config_get_cores(cores, 16);
+    printf("There are %lu cores\n", cores_count);
+
+    for (int i = 0; i < cores_count; i += 1) {
+        printf("Core: %d\n", cores[i]);
+    }
 
     while(true) {
         uint16_t count = pv_nic_rx_burst(0, 0, packets, 64);

--- a/include/pv/config.h
+++ b/include/pv/config.h
@@ -5,8 +5,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <cl/map.h>
-
 struct pv_config_memory {
     uint32_t packet_pool;   // Count
     uint32_t shared_memory; // Bytes
@@ -45,6 +43,9 @@ struct pv_config {
     uint16_t* cores;
     uint16_t cores_count;
 
+    size_t eal_argc;
+    char** eal_argv;
+
     struct pv_config_memory memory;
 
     struct pv_config_nic* nics;
@@ -56,6 +57,22 @@ struct pv_config {
 struct pv_config* pv_config_create();
 void pv_config_destroy(struct pv_config* config);
 void pv_config_finalize();
+
+/**
+ * Get cores count that specified on config file.
+ * @return count of cores
+ */
+size_t pv_config_get_core_count();
+
+/**
+ * Get cores list from config file.
+ * @param cores array of int to store core ids.
+ * @param max_count maximum count to store core ids. if there are more than this value. they are ignored. @see pv_config_get_core_count
+ * @return count of cores that is returned from this function.
+ */
+size_t pv_config_get_cores(int* cores, size_t max_count);
+
+// Below are for custom configs
 
 /**
  * Check if config has value with given key.

--- a/pypv/pv.py
+++ b/pypv/pv.py
@@ -78,7 +78,7 @@ def main(args: List[str]) -> int:
     eal_params = config['eal_params']
 
     try:
-        cores = config.get('cores', 0)
+        cores = config.get('cores', [])
         if len(cores) == 0:
             raise ValueError('Invalid core count')
 

--- a/src/pv.c
+++ b/src/pv.c
@@ -114,12 +114,7 @@ int pv_init() {
         return -1;
     }
 
-    char* argv[] = {
-        "xxx",
-    };
-    int argc = sizeof(argv) / sizeof(argv[0]);
-
-    int ret = rte_eal_init(argc, argv);
+    int ret = rte_eal_init(config->eal_argc, config->eal_argv);
     if(ret < 0) {
         error_with_rte(1, "Error with EAL initialization\n");
     }


### PR DESCRIPTION
- Add function pv_config_get_cores
- Add function pv_config_cores_count
- Use eal_params from config to init dpdk
- Dump cores config from example app "dump"