### PR TITLE
Fix sending order on NIC::send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,8 +498,9 @@ impl NIC {
             /* insert packets to be send into TX ring (Enqueue) */
             let tx_desc_ptr = unsafe { xsk_ring_prod__tx_desc(&mut self.tx, tx_idx + i) };
             unsafe {
-                tx_desc_ptr.as_mut().unwrap().addr = pkt.private as u64 + pkt.start as u64;
-                tx_desc_ptr.as_mut().unwrap().len = (pkt.end - pkt.start) as u32;
+                let tx_desc = tx_desc_ptr.as_mut().unwrap();
+                tx_desc.addr = pkt.private as u64 + pkt.start as u64;
+                tx_desc.len = (pkt.end - pkt.start) as u32;
             }
         }
         packets.drain(0..reserved as usize); // remove packets which have been sent from packets vector


### PR DESCRIPTION
There is no reason to send packets in reverse order.