### PR TITLE
Make Packet.dump to print only related area

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ impl Packet {
         let chunk_address = self.private as u64;
         let buffer_address: *const u8 = self.buffer.cast_const();
 
+        let length: usize = self.end - self.start;
         let mut count: usize = 0;
 
         unsafe {
@@ -139,7 +140,7 @@ impl Packet {
                 print!("{:02X?} ", std::ptr::read(read_address));
 
                 count += 1;
-                if count == self.end - self.start {
+                if count == length {
                     break;
                 } else if count % 8 == 0 {
                     print!(" ");


### PR DESCRIPTION
Before
![Screenshot from 2023-11-17 13-03-17](https://github.com/tsnlab/packetvisor/assets/63575184/fb01c302-3488-4721-b493-b506e46fe7a4)

After
![Screenshot from 2023-11-17 13-01-02](https://github.com/tsnlab/packetvisor/assets/63575184/b6af6fb9-09c6-4e4f-9252-49a97d4964e0)
