### PR TITLE
Add XSK Generic/Native Fallback feature

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -112,15 +112,13 @@ fn main() {
     }
 
     let mut nic = pv::NIC::new(&if_name, chunk_size, chunk_count).unwrap();
-    match nic.open(
+    nic.open(
         rx_ring_size,
         tx_ring_size,
         filling_ring_size,
         completion_ring_size,
-    ) {
-        Ok(_) => {}
-        Err(_) => std::process::exit(1),
-    };
+    )
+    .expect("Cannot open NIC");
 
     /* initialize rx_batch_size and packet metadata */
     let rx_batch_size: u32 = 64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,13 +438,19 @@ impl NIC {
         if ret != 0 {
             /* If failed to create XSK socket with native(DRV) mode
              * Then create XSK socket with generic(SKB) mode */
-            println!("Failed to create native mode of XSK");
-            println!("Fallback to create generic mode of XSK");
+            eprintln!(
+                "Failed to create XSK in native mode on '{}'",
+                self.interface.name
+            );
+            eprintln!(
+                "Falling back to XSK in generic mode on '{}'",
+                self.interface.name
+            );
 
             /* Clear UMEM to retry XSK init */
             unsafe { xsk_umem__delete(self.umem) };
 
-            /* Sleep to completely clear UMEM */
+            /* Wait for UMEM to be completely clear */
             std::thread::sleep(std::time::Duration::from_millis(100));
 
             /* Retry UMEM init */


### PR DESCRIPTION
The PV library cannot automatically convert the XSK mode internally. This is due to an issue with the `xsk_socket__create()` API, which cannot be reused.

~~Therefore, I have added the `xdp_mode` parameter to the input parameters of `pv::NIC::open()` so that users can set it directly.~~

~~The following is an example code for a user using PV.~~
~~If `open()` fails, the user must terminate the process and restart it.~~
```Rust
match nic.open(
    rx_ring_size,
    tx_ring_size,
    filling_ring_size,
    completion_ring_size,
    pv::XdpMode::GenericMode, //pv::XdpMode::NativeMode,
) {
    Ok(_) => {}
    Err(_) => std::process::exit(1),
};
```
<br/>

~~And, following the addition of the xdp_mode parameter to `pv::NIC::open()`, I have modified the example source codes(echo.rs, filter.rs, etc..).~~