### PR TITLE
Fix segfault when Nic::open() fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,9 +340,7 @@ impl BufferPool {
 
 impl Pool {
     fn new() -> Result<Self, String> {
-        let umem_ptr = alloc_zeroed_layout::<xsk_umem>()?;
-
-        let umem = umem_ptr.cast::<xsk_umem>(); // umem is needed to be dealloc after using packetvisor library.
+        let umem: *mut xsk_umem = std::ptr::null_mut();
         let fq: xsk_ring_prod = unsafe { std::mem::zeroed() };
         let cq: xsk_ring_cons = unsafe { std::mem::zeroed() };
 
@@ -503,8 +501,6 @@ impl Nic {
             .find(|elem| elem.name.as_str() == if_name)
             .ok_or(format!("Interface {} not found.", if_name))?;
 
-        let xsk_ptr = alloc_zeroed_layout::<xsk_socket>()?;
-
         /* The result of Pool::init() must be unwrapped using the unwrap() function. \
          * If you do not use unwrap(), the internal fields of the Pool object will not \
          * be properly initialized, which can lead to potential problems.
@@ -515,7 +511,7 @@ impl Nic {
 
         let mut nic = Nic {
                 interface: interface.clone(),
-                xsk: xsk_ptr.cast::<xsk_socket>(),
+                xsk: std::ptr::null_mut(),
                 rxq: unsafe { std::mem::zeroed() },
                 txq: unsafe { std::mem::zeroed() },
                 umem_fq: unsafe { std::mem::zeroed() },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,12 +341,10 @@ impl BufferPool {
 impl Pool {
     fn new() -> Result<Self, String> {
         let umem_ptr = alloc_zeroed_layout::<xsk_umem>()?;
-        let fq_ptr = alloc_zeroed_layout::<xsk_ring_prod>()?;
-        let cq_ptr = alloc_zeroed_layout::<xsk_ring_cons>()?;
 
         let umem = umem_ptr.cast::<xsk_umem>(); // umem is needed to be dealloc after using packetvisor library.
-        let fq = unsafe { std::ptr::read(fq_ptr.cast::<xsk_ring_prod>()) };
-        let cq = unsafe { std::ptr::read(cq_ptr.cast::<xsk_ring_cons>()) };
+        let fq: xsk_ring_prod = unsafe { std::mem::zeroed() };
+        let cq: xsk_ring_cons = unsafe { std::mem::zeroed() };
 
         let chunk_pool = BufferPool::new(0, 0, std::ptr::null_mut(), 0, 0);
 
@@ -506,10 +504,6 @@ impl Nic {
             .ok_or(format!("Interface {} not found.", if_name))?;
 
         let xsk_ptr = alloc_zeroed_layout::<xsk_socket>()?;
-        let rx_ptr = alloc_zeroed_layout::<xsk_ring_cons>()?;
-        let tx_ptr = alloc_zeroed_layout::<xsk_ring_prod>()?;
-        let fq_ptr = alloc_zeroed_layout::<xsk_ring_prod>()?;
-        let cq_ptr = alloc_zeroed_layout::<xsk_ring_cons>()?;
 
         /* The result of Pool::init() must be unwrapped using the unwrap() function. \
          * If you do not use unwrap(), the internal fields of the Pool object will not \
@@ -519,15 +513,13 @@ impl Nic {
          *     Other unexpected problems may occur. */
         Pool::init(chunk_size, chunk_count, fq_size, cq_size).unwrap();
 
-        let mut nic = unsafe {
-            Nic {
+        let mut nic = Nic {
                 interface: interface.clone(),
                 xsk: xsk_ptr.cast::<xsk_socket>(),
-                rxq: std::ptr::read(rx_ptr.cast::<xsk_ring_cons>()),
-                txq: std::ptr::read(tx_ptr.cast::<xsk_ring_prod>()),
-                umem_fq: std::ptr::read(fq_ptr.cast::<xsk_ring_prod>()),
-                umem_cq: std::ptr::read(cq_ptr.cast::<xsk_ring_cons>()),
-            }
+                rxq: unsafe { std::mem::zeroed() },
+                txq: unsafe { std::mem::zeroed() },
+                umem_fq: unsafe { std::mem::zeroed() },
+                umem_cq: unsafe { std::mem::zeroed() },
         };
 
         match Nic::open(
@@ -653,10 +645,8 @@ impl Nic {
                 self.umem_fq = (*pool).umem_fq;
                 self.umem_cq = (*pool).umem_cq;
 
-                let fq_ptr = alloc_zeroed_layout::<xsk_ring_prod>()?;
-                let cq_ptr = alloc_zeroed_layout::<xsk_ring_cons>()?;
-                (*pool).umem_fq = std::ptr::read(fq_ptr.cast::<xsk_ring_prod>());
-                (*pool).umem_cq = std::ptr::read(cq_ptr.cast::<xsk_ring_cons>());
+                (*pool).umem_fq = std::mem::zeroed();
+                (*pool).umem_cq = std::mem::zeroed();
             };
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,10 @@ impl Nic {
                 Ok(nic)
             }
             Err(e) => {
-                // FIXME: Print here is fine. But segfault happened when printing in the caller.
+				if !nic.xsk.is_null() {
+					unsafe { xsk_socket__delete(nic.xsk); }
+					nic.xsk = std::ptr::null_mut();
+      			}
                 eprintln!("Failed to open NIC: {}", e);
                 Err(e)
             }
@@ -844,6 +847,9 @@ impl Drop for Nic {
     // move ownership of nic
     fn drop(&mut self) {
         // xsk delete
+		if self.xsk.is_null() {
+			return;
+		}
         unsafe {
             xsk_socket__delete(self.xsk);
             let pool = Pool::instance();


### PR DESCRIPTION
- Fix [FIXME](https://github.com/tsnlab/packetvisor/blob/5b05ecc1d8b21675bdbad821bd36bce258b97f51/src/lib.rs#L550): segfault when Nic::open() fails

  Cause: xsk was heap-allocated zeroed memory, not NULL. Drop called xsk_socket__delete() on it.

  Fix: use null_mut() instead of heap allocation. cleanup xsk in error path, set to NULL. Skip Drop if NULL.

  [xsk_socket__delete](https://github.com/xdp-project/xdp-tools/blob/30f375169a7f0b44d4331589a0fe79631a8b79c2/lib/libxdp/xsk.c#L1359)
  [xsk_socket__create_shared](https://github.com/xdp-project/xdp-tools/blob/master/lib/libxdp/xsk.c#L1268)