### PR TITLE
Expose AfXdpRxConfig and handle partial FQ reservation

### DIFF
--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -23,7 +23,7 @@ jobs:
         uses: tsnlab/check@main
         with:
           python_version: '3.12'
-          rust_version: 'stable'
+          rust_version: '1.88.0'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           shellcheck_ignore_paths: >-
             bpftool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod bindings {
     #![allow(non_camel_case_types)]
     #![allow(non_snake_case)]
     #![allow(dead_code)]
+    #![allow(improper_ctypes)]
     #![allow(clippy::all)]
 
     #[cfg(docsrs)]
@@ -187,7 +188,7 @@ impl BufferPool {
 
         #[cfg(debug_assertions)]
         if self.pool.contains(&chunk_addr) {
-            eprintln!("Chunk Pool already contains chunk_addr: {}", chunk_addr);
+            eprintln!("Chunk Pool already contains chunk_addr: {chunk_addr}");
         }
 
         self.pool.insert(chunk_addr);
@@ -462,7 +463,7 @@ impl Pool {
                     .into_owned()
             };
 
-            return Err(format!("Failed to create UMEM: {}", msg));
+            return Err(format!("Failed to create UMEM: {msg}"));
         }
 
         let chunk_pool = BufferPool::new(chunk_size, chunk_count, mmap_address, fq_size, cq_size);
@@ -513,6 +514,7 @@ impl Nic {
     /// # Returns
     /// On success, returns `pv::Nic` bound to the network interface. \
     /// On failure, returns an error string.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         if_name: &str,
         chunk_size: usize,
@@ -528,11 +530,11 @@ impl Nic {
         let bpf_obj_path = env!("BPF_OBJECT_PATH");
 
         let bpf_obj_cstr =
-            CString::new(bpf_obj_path).map_err(|e| format!("Failed to create CString: {}", e))?;
+            CString::new(bpf_obj_path).map_err(|e| format!("Failed to create CString: {e}"))?;
 
         // Program name in the BPF object file
         let prog_name_cstr = CString::new("xsk_packetvisor_prog")
-            .map_err(|e| format!("Failed to create CString for program name: {}", e))?;
+            .map_err(|e| format!("Failed to create CString for program name: {e}"))?;
 
         // Initialize xdp_program_opts
         let mut opts = xdp_program_opts {
@@ -569,14 +571,14 @@ impl Nic {
                     .to_string_lossy()
                     .to_string()
             };
-            return Err(format!("Failed to load XDP program: {} ({})", err_str, err));
+            return Err(format!("Failed to load XDP program: {err_str} ({err})"));
         }
 
         // Find interface first to get ifindex
         let interface = interfaces()
             .into_iter()
             .find(|elem| elem.name.as_str() == if_name)
-            .ok_or(format!("Interface {} not found.", if_name))?;
+            .ok_or(format!("Interface {if_name} not found."))?;
 
         // Get interface index
         let ifindex = interface.index as i32;
@@ -600,8 +602,7 @@ impl Nic {
                         .to_string()
                 };
                 return Err(format!(
-                    "Failed to attach XDP program to interface: {} ({})",
-                    err_str, ret
+                    "Failed to attach XDP program to interface: {err_str} ({ret})"
                 ));
             }
         }
@@ -613,7 +614,7 @@ impl Nic {
         }
 
         let xsks_map_name =
-            CString::new("xsks_map").map_err(|e| format!("Failed to create CString: {}", e))?;
+            CString::new("xsks_map").map_err(|e| format!("Failed to create CString: {e}"))?;
         let xsks_map = unsafe { bpf_object__find_map_by_name(bpf_obj, xsks_map_name.as_ptr()) };
         if xsks_map.is_null() {
             return Err("Failed to find xsks_map in BPF object".to_string());
@@ -622,14 +623,13 @@ impl Nic {
         let xsks_map_fd = unsafe { bpf_map__fd(xsks_map) };
         if xsks_map_fd < 0 {
             return Err(format!(
-                "Failed to get xsks_map file descriptor: {}",
-                xsks_map_fd
+                "Failed to get xsks_map file descriptor: {xsks_map_fd}"
             ));
         }
 
         // Get config_map file descriptor for passing values to XDP program
         let config_map_name =
-            CString::new("config_map").map_err(|e| format!("Failed to create CString: {}", e))?;
+            CString::new("config_map").map_err(|e| format!("Failed to create CString: {e}"))?;
         let config_map = unsafe { bpf_object__find_map_by_name(bpf_obj, config_map_name.as_ptr()) };
         let config_map_fd = if config_map.is_null() {
             -1 // Map not found, optional map
@@ -663,10 +663,7 @@ impl Nic {
                 )
             };
             if update_ret != 0 {
-                eprintln!(
-                    "Warning: Failed to initialize config_map: ret={}",
-                    update_ret
-                );
+                eprintln!("Warning: Failed to initialize config_map: ret={update_ret}");
             } else {
                 // Verify the update
                 let mut verify_value = AfXdpRxConfig::default();
@@ -678,10 +675,7 @@ impl Nic {
                     )
                 };
                 if verify_ret == 0 {
-                    eprintln!(
-                        "Debug: config_map initialized with value: {:?}",
-                        verify_value
-                    );
+                    eprintln!("Debug: config_map initialized with value: {verify_value:?}");
                 } else {
                     eprintln!("Warning: Failed to verify config_map initialization");
                 }
@@ -740,7 +734,7 @@ impl Nic {
             }
             Err(e) => {
                 // FIXME: Print here is fine. But segfault happened when printing in the caller.
-                eprintln!("Failed to open NIC: {}", e);
+                eprintln!("Failed to open NIC: {e}");
                 Err(e)
             }
         }
@@ -789,8 +783,8 @@ impl Nic {
                         .to_string_lossy()
                         .into_owned()
                 };
-                let message = format!("Error: {}", msg);
-                return Err(format!("xsk_socket__update_xskmap failed: {}", message));
+                let message = format!("Error: {msg}");
+                return Err(format!("xsk_socket__update_xskmap failed: {message}"));
             }
         }
 
@@ -840,8 +834,8 @@ impl Nic {
                             .to_string_lossy()
                             .into_owned()
                     };
-                    let message = format!("Error: {}", msg);
-                    return Err(format!("xsk_socket__update_xskmap failed: {}", message));
+                    let message = format!("Error: {msg}");
+                    return Err(format!("xsk_socket__update_xskmap failed: {message}"));
                 }
             }
 
@@ -851,8 +845,8 @@ impl Nic {
                         .to_string_lossy()
                         .into_owned()
                 };
-                let message = format!("Error: {}", msg);
-                return Err(format!("xsk_socket__create failed: {}", message));
+                let message = format!("Error: {msg}");
+                return Err(format!("xsk_socket__create failed: {message}"));
             }
         }
 
@@ -980,8 +974,7 @@ impl Nic {
                     .into_owned()
             };
             return Err(format!(
-                "Failed to update config_map: {} (ret={}, errno={})",
-                msg, ret, errno
+                "Failed to update config_map: {msg} (ret={ret}, errno={errno})"
             ));
         }
 
@@ -1014,7 +1007,7 @@ impl Nic {
                     .to_string_lossy()
                     .into_owned()
             };
-            return Err(format!("Failed to lookup config_map: {} ({})", msg, ret));
+            return Err(format!("Failed to lookup config_map: {msg} ({ret})"));
         }
 
         Ok(value)
@@ -1115,7 +1108,7 @@ impl Packet {
         let mut count: usize = 0;
 
         unsafe {
-            println!("---packet dump--- chunk addr: {}", chunk_address);
+            println!("---packet dump--- chunk addr: {chunk_address}");
 
             loop {
                 let read_offset: usize = count + self.start;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,20 +201,21 @@ impl BufferPool {
 
     /// Reserve FQ and UMEM chunks as much as **len
     fn reserve_fq(&mut self, fq: &mut xsk_ring_prod, len: usize) -> Result<usize, &'static str> {
-        let mut cq_idx = 0;
-        let mut reserved = unsafe { xsk_ring_prod__reserve(fq, len as u32, &mut cq_idx) };
+        let available = len
+            .min(self.pool.len())
+            .min(unsafe { xsk_prod_nb_free(fq, len as u32) as usize });
+
+        if available == 0 {
+            return Ok(0);
+        }
+
+        let mut fq_idx = 0;
+        let reserved = unsafe { xsk_ring_prod__reserve(fq, available as u32, &mut fq_idx) };
 
         // Allocate UMEM chunks into fq
         for i in 0..reserved {
             unsafe {
-                let addr = match self.alloc_addr() {
-                    Ok(addr) => addr,
-                    Err(_) => {
-                        reserved = i;
-                        break;
-                    }
-                };
-                *xsk_ring_prod__fill_addr(fq, cq_idx + i) = addr;
+                *xsk_ring_prod__fill_addr(fq, fq_idx + i) = self.alloc_addr().unwrap();
             }
         }
 
@@ -255,6 +256,21 @@ impl BufferPool {
         Ok(count)
     }
 
+    fn wake_rx_if_needed(&self, xsk: &*mut xsk_socket, fq: &mut xsk_ring_prod) {
+        unsafe {
+            if xsk_ring_prod__needs_wakeup(&*fq) != 0 {
+                libc::recvfrom(
+                    xsk_socket__fd(*xsk),
+                    std::ptr::null_mut::<libc::c_void>(),
+                    0 as libc::size_t,
+                    libc::MSG_DONTWAIT,
+                    std::ptr::null_mut::<libc::sockaddr>(),
+                    std::ptr::null_mut::<u32>(),
+                );
+            }
+        }
+    }
+
     fn recv(
         &mut self,
         chunk_pool_rc: &Rc<RefCell<Self>>,
@@ -291,8 +307,7 @@ impl BufferPool {
             xsk_ring_cons__release(rxq, received);
         }
 
-        self.reserve_fq(fq, packets.len()).unwrap();
-
+        self.reserve_fq(fq, self.fq_size).unwrap();
         /*
          * XSK manages interrupts through xsk_ring_prod__needs_wakup().
          *
@@ -300,18 +315,7 @@ impl BufferPool {
          * This significantly degrades Packetvisor performance.
          * To resolve this issue, the interrupt is woken up whenever Recv() is called.
          */
-        unsafe {
-            if xsk_ring_prod__needs_wakeup(&*fq) != 0 {
-                libc::recvfrom(
-                    xsk_socket__fd(*_xsk),
-                    std::ptr::null_mut::<libc::c_void>(),
-                    0 as libc::size_t,
-                    libc::MSG_DONTWAIT,
-                    std::ptr::null_mut::<libc::sockaddr>(),
-                    std::ptr::null_mut::<u32>(),
-                );
-            }
-        }
+        self.wake_rx_if_needed(_xsk, fq);
 
         packets
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-mod xdp_config;
+pub mod xdp_config;
 
 use bindings::*;
 use pnet::datalink::{interfaces, NetworkInterface};
@@ -65,7 +65,7 @@ use std::time::Duration;
 
 use libc::strerror;
 
-use crate::xdp_config::AfXdpRxConfig;
+pub use crate::xdp_config::AfXdpRxConfig;
 
 const DEFAULT_HEADROOM: usize = 256;
 
@@ -201,12 +201,19 @@ impl BufferPool {
     /// Reserve FQ and UMEM chunks as much as **len
     fn reserve_fq(&mut self, fq: &mut xsk_ring_prod, len: usize) -> Result<usize, &'static str> {
         let mut cq_idx = 0;
-        let reserved = unsafe { xsk_ring_prod__reserve(fq, len as u32, &mut cq_idx) };
+        let mut reserved = unsafe { xsk_ring_prod__reserve(fq, len as u32, &mut cq_idx) };
 
         // Allocate UMEM chunks into fq
         for i in 0..reserved {
             unsafe {
-                *xsk_ring_prod__fill_addr(fq, cq_idx + i) = self.alloc_addr()?;
+                let addr = match self.alloc_addr() {
+                    Ok(addr) => addr,
+                    Err(_) => {
+                        reserved = i;
+                        break;
+                    }
+                };
+                *xsk_ring_prod__fill_addr(fq, cq_idx + i) = addr;
             }
         }
 

--- a/src/xdp_config.rs
+++ b/src/xdp_config.rs
@@ -40,7 +40,10 @@ impl AfXdpRxConfig {
     pub fn all_filter() -> Self {
         Self {
             l2_flags: Self::L2_FLAGS_ETH | Self::L2_FLAGS_VLAN | Self::L2_FLAGS_ARP,
-            l3_flags: Self::L3_FLAGS_IPV4 | Self::L3_FLAGS_IPV6 | Self::L3_FLAGS_EAPOL | Self::L3_FLAGS_OTHER,
+            l3_flags: Self::L3_FLAGS_IPV4
+                | Self::L3_FLAGS_IPV6
+                | Self::L3_FLAGS_EAPOL
+                | Self::L3_FLAGS_OTHER,
             l4_flags: 0,
         }
     }


### PR DESCRIPTION
### [Expose AfXdpRxConfig and handle partial FQ reservation](https://github.com/tsnlab/packetvisor/pull/100/changes/30b72d35d92f4a553ce73919dc3e5bb605610344)
- `xdp_config` 모듈을 외부에서 접근할 수 있도록 접근 권한을 private에서 public으로 변경
외부에서 `AfXdpRxConfig`에 쉽게 접근 할 수 있도록 노출.

### [Fix linting issues](https://github.com/tsnlab/packetvisor/pull/100/changes/65889a2b83a35f8ae160da87fbcfae1c4d4f3a13)
- cargo clippy, cargo fmt 이슈 사항 수정

### [Update Rust version to 1.88.0 in CI workflow](https://github.com/tsnlab/packetvisor/pull/100/changes/4283cc4d27142d0503b645c3d4fe91e77f1e3e9c)
- github action rust 버전 수정


### [Fix FQ reservation logic and add wake-up mechanism for RX](https://github.com/tsnlab/packetvisor/pull/100/changes/dfaffdbe49842de593699543b10f28aeba04115e)
- `BufferPool::reserve_fq`에서 xsk_ring과 pool사이즈를 비교해서 최대 범위를 구한다.

- `BufferPool::recv`에서 `BufferPool::reserve_fq` 호출할때 파라미터로 packets_len()이 아닌 fq_size를 주어서 보다 안정하게 범위를 주게 한다.

