### PR TITLE
Add packetvisor fd accessor for polling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-mod xdp_config;
+pub mod xdp_config;
 
 use bindings::*;
 use pnet::datalink::{interfaces, NetworkInterface};
@@ -893,6 +893,12 @@ impl Nic {
     /// On failure, returns `None`.
     pub fn alloc_packet(&self) -> Option<Packet> {
         unsafe { (*Pool::instance()).try_alloc_packet() }
+    }
+
+    /// # Description
+    /// Return the underlying AF_XDP socket file descriptor.
+    pub fn fd(&self) -> i32 {
+        unsafe { xsk_socket__fd(self.xsk) }
     }
 
     /// # Description

--- a/src/xdp_config.rs
+++ b/src/xdp_config.rs
@@ -40,7 +40,10 @@ impl AfXdpRxConfig {
     pub fn all_filter() -> Self {
         Self {
             l2_flags: Self::L2_FLAGS_ETH | Self::L2_FLAGS_VLAN | Self::L2_FLAGS_ARP,
-            l3_flags: Self::L3_FLAGS_IPV4 | Self::L3_FLAGS_IPV6 | Self::L3_FLAGS_EAPOL | Self::L3_FLAGS_OTHER,
+            l3_flags: Self::L3_FLAGS_IPV4
+                | Self::L3_FLAGS_IPV6
+                | Self::L3_FLAGS_EAPOL
+                | Self::L3_FLAGS_OTHER,
             l4_flags: 0,
         }
     }


### PR DESCRIPTION
1. Purpose
Expose PacketVisor socket fd so MCTP NAT can use poll() instead of busy-loop polling.

2. Overview
Make xdp_config public for MCTP use.
Add Nic::fd() to return the AF_XDP socket fd.
Apply rustfmt cleanup in xdp_config.rs